### PR TITLE
removed sticky.min.js script

### DIFF
--- a/index.html
+++ b/index.html
@@ -918,6 +918,5 @@
 cb=googleTranslateElementInit"
       defer
     ></script>
-    <script src="sticky.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I am pretty sure we don't need this script. I removed it and the sticky navbar is working just fine.